### PR TITLE
Opdatering af parameter for pdfTEX (pdflatex)

### DIFF
--- a/scripts/excom.py
+++ b/scripts/excom.py
@@ -52,7 +52,7 @@ class TeXProcess():
          except TypeError:
             jobname = texfile.stem
 
-         self.job_name = [ "-job-name=" ]
+         self.job_name = [ "-jobname=" ]
          try:
             self.job_name[0] += str(
                jobdir.relative_to( self.exec_dir ) / jobname


### PR DESCRIPTION
Parameteren "-job-name" for pdflatex er i Ubuntu 24.04 LTS (testet version) ændret til "-jobname".
Formentlig samme tilfælde i andre distributioner. Kræver test.
Resultatet er, at kompilering af TeX filerne ikke får rigtige navne og kørslen derfor fejler.
Opdateret dokumentation for pdfTEX: https://texdoc.org/serve/pdftex-a.pdf/0